### PR TITLE
Change create-sftp-user to honor gid for the directories

### DIFF
--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -97,7 +97,7 @@ if [ -n "$dir" ]; then
         if [ ! -d "$dirPath" ]; then
             log "Creating directory: $dirPath"
             mkdir -p "$dirPath"
-            chown -R "$uid:users" "$dirPath"
+            chown -R "$uid:$gid" "$dirPath"
         else
             log "Directory already exists: $dirPath"
         fi


### PR DESCRIPTION
The gid is not being properly set for newly created dirs.  Looks like the group "users" is hard coded instead.